### PR TITLE
Using linear and mux caches instead of simple

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,13 @@ This is an example of XDS server implementation using [envoy-control-plane](http
 
 There are some gRPC servers (backends), some XDS management servers (depends on local or k8s versions), and some clients (frontends) that make several RPC calls to the backend. 
 
-All required discovery services (resources) prepared by the XDS management server using `envoy`'s control plane, and every request from the client being resolved by `grpc-go` `xds` resolver. Under the hood, there is some magic that `grpc-go` doing with its `service config`. Check out [proposal][proposal] for more information about the basic principles of xDS requests and response processing.
+All required discovery services (resources) prepared by the XDS management server using `envoy`'s control plane, and every request from the client being resolved by `grpc-go` `xds` resolver. Under the hood, there is some magic that `grpc-go` doing with its `service config`. Check out [proposal-A27][proposal-a27] and [proposal-A28][proposal-a28] for more information about the basic principles of xDS requests and response processing.
 
-The localhost example supports simple and naive emulation of updating/adding new endpoints (just RR through upstreams) to represent balancing within 2 backends.
+The localhost example supports simple and naive emulation of updating/adding new endpoints (just RR through upstreams) to represent scaling/updates within 2 backends.
 
 The k8s example is a more robust way to represent how it will work in your k8s cluster. 
 
->Note that for simplifications the k8s example produces snapshots of the whole cluster state (in other words — `State of the World`), **do not use it on production** since this is a big overhead because every frontend will receive the whole cache every time.
+Note that for simplifications both examples produce [config caches](https://github.com/envoyproxy/go-control-plane#resource-caching) of the whole cluster state (in other words — `State of the World`). This behaviour can be easily improved because I use [`MuxCache`](https://pkg.go.dev/github.com/envoyproxy/go-control-plane@v0.9.7/pkg/cache/v2#MuxCache) that combines several [`LinearCache`](https://pkg.go.dev/github.com/envoyproxy/go-control-plane@v0.9.7/pkg/cache/v2#LinearCache) each of appropriate [`TypeUrl`](https://pkg.go.dev/github.com/envoyproxy/go-control-plane@v0.9.7/pkg/resource/v2#pkg-constants).
 
 I mostly didn't care about system design of this playground repository, so there is a bunch of boilerplate code. This playground was a kind of research for me, do not shame on me 🤗
 
@@ -30,17 +30,18 @@ $ make local_client_xds # run target local_client_xds_debug to enable grpc verbo
 
 ### k8s example
 
-I use minikube as a local k8s cluster, so you should install it (i.e. on macOS using [brew](https://brew.sh/)):
+I use `minikube` as a local k8s cluster and `helm` to deploy resources, so you should install them (i.e. on macOS using [brew](https://brew.sh/)):
 
 ```shell
 $ brew install minikube
+$ brew install helm
 ```
 
 Use the following targets to simply run the whole example, then check out logs to investigate what's going on:
 
 ```shell
 $ minikube start # start k8s cluster
-$ eval $(minikube docker-env) # escale using local registry, works only on terminal where you entered this command
+$ eval $(minikube docker-env) # escape usage of local registry, works only on terminal where you entered this command
 $ make deploy # deploy services
 ```
 
@@ -58,17 +59,18 @@ $ kubectl logs -lapp=frontend # frontend with grpc debug level
 
 The main idea of these examples is to show a quick presentation of how to bake `grpc-go` with its `xds` resolver ([v1.32.0](https://github.com/grpc/grpc-go/releases/tag/v1.32.0) at this moment).
 
-The main problem is the usage of [snapshots](https://pkg.go.dev/github.com/envoyproxy/go-control-plane@v0.9.7/pkg/cache/v2#Snapshot), this is not very flexible because it binds us to customize work with custom `nodeIDs` using custom [callbacks](https://pkg.go.dev/github.com/envoyproxy/go-control-plane@v0.9.7/pkg/server/v2#CallbackFuncs) or use SotW snapshots (that is a big overhead).
-
-Potentially this could be resolved in a simple way — using your own cache (i.e. [LinearCache](https://pkg.go.dev/github.com/envoyproxy/go-control-plane@v0.9.7/pkg/cache/v2#LinearCache)) and updating resources by hand simply calling for [UpdateResouce](https://pkg.go.dev/github.com/envoyproxy/go-control-plane@v0.9.7/pkg/cache/v2#LinearCache.UpdateResource) method of cache instance.
+The next issue to solve is to implement a kind of [incremental xDS](https://www.envoyproxy.io/docs/envoy/latest/api-docs/xds_protocol#four-variants) (because I used to use `SotW` as I mentioned above), but I think it's beyond this playground.
 
 ## References
 
-1. [xDS-Based Global Load Balancing Proposal][proposal]
+1. [xDS-Based Global Load Balancing Proposal][proposal-a27]
+1. [gRPC xDS traffic splitting and routing][proposal-a28]
 1. [Envoy's example of usage and configuring control plane][dyplomat]
 1. [This article with pretty good example of usage and control plane configuring][article]
 
-[proposal]:https://github.com/grpc/proposal/blob/master/A27-xds-global-load-balancing.md
+[proposal-a27]:https://github.com/grpc/proposal/blob/master/A27-xds-global-load-balancing.md
+
+[proposal-a28]:https://github.com/grpc/proposal/blob/master/A28-xds-traffic-splitting-and-routing.md
 
 [dyplomat]:https://github.com/envoyproxy/go-control-plane/blob/master/examples/dyplomat/readme.md
 

--- a/cmd/xds_k8s/ds.go
+++ b/cmd/xds_k8s/ds.go
@@ -96,6 +96,7 @@ func (c *k8sInMemoryState) initState(epsInformer cache.SharedIndexInformer) erro
 	// c.cacheRds = xds_cache.NewLinearCache(resource.RouteType, xds_cache.WithInitialResources(map[string]types.Resource{serviceName: rds[0]}))
 	// c.cacheLds = xds_cache.NewLinearCache(resource.ListenerType, xds_cache.WithInitialResources(map[string]types.Resource{serviceName: lds[0]}))
 	if len(svc2Eps) > 0 {
+		log.Printf("setting new cache: %+v %+v %+v %+v\n", eds[0], cds[0], rds[0], lds[0])
 		c.cacheAny = xds_cache.NewLinearCache(resource.AnyType, xds_cache.WithInitialResources(map[string]types.Resource{
 			"eds": eds[0],
 			"cds": cds[0],
@@ -120,6 +121,7 @@ func (c *k8sInMemoryState) initState(epsInformer cache.SharedIndexInformer) erro
 }
 
 func getSnapshot(svc2Eps map[string][]podEndpoint, localitiesZone2Reg map[string]string) (xds_cache.Snapshot, error) {
+	return xds_cache.Snapshot{}, nil
 	var (
 		eds, cds, rds, lds []types.Resource
 	)

--- a/cmd/xds_k8s/k8s.go
+++ b/cmd/xds_k8s/k8s.go
@@ -8,6 +8,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/envoyproxy/go-control-plane/pkg/cache/types"
 	xds_cache "github.com/envoyproxy/go-control-plane/pkg/cache/v2"
 	core "k8s.io/api/core/v1"
 	"k8s.io/client-go/informers"
@@ -20,6 +21,11 @@ const meshNodeName = "mesh"
 
 type k8sInMemoryState struct {
 	snapshotCache xds_cache.SnapshotCache
+	cacheEds      *xds_cache.LinearCache
+	cacheCds      *xds_cache.LinearCache
+	cacheRds      *xds_cache.LinearCache
+	cacheLds      *xds_cache.LinearCache
+	cacheAny      *xds_cache.LinearCache
 
 	mu sync.RWMutex
 
@@ -78,6 +84,78 @@ func (c *k8sInMemoryState) onDelete(obj interface{}) {
 
 func (c *k8sInMemoryState) onAdd(obj interface{}) {
 	c.onEventProcess(obj, "add")
+}
+
+func (c *k8sInMemoryState) onUpdateC(oldObj, newObj interface{}) {
+	c.onEventProcess(newObj, "update")
+}
+
+func (c *k8sInMemoryState) onDeleteC(obj interface{}) {
+	c.onEventProcess(obj, "delete")
+}
+
+func (c *k8sInMemoryState) onAddC(obj interface{}) {
+	c.onEventProcess(obj, "add")
+}
+
+func (c *k8sInMemoryState) onEventProcessC(obj interface{}, eventType string) {
+	endpoints, ok := obj.(*core.Endpoints)
+	if !ok || endpoints == nil {
+		return
+	}
+
+	svcName, podEndpoints := endpoints.GetObjectMeta().GetName(), extractDataFromEndpoints(endpoints)
+
+	// sanity check
+	c.mu.RLock()
+	if _, ok := c.svcState[svcName]; !ok {
+		c.mu.RUnlock()
+		return
+	}
+	c.mu.RUnlock()
+
+	c.mu.Lock()
+	c.svcState[svcName] = podEndpoints
+	c.mu.Unlock()
+
+	// NOTE: in this method we can extract locality data from endpoint in some way
+	c.mu.RLock()
+	var (
+		eds, cds, rds, lds []types.Resource
+	)
+	for svc, eps := range c.svcState {
+		eds = append(eds, getEDS(eps, map[string]string{zoneNameHC: regionNameHC})...)
+		cds = append(cds, getCDS()...)
+
+		svcRouteConfigName := svc + "-route-config"
+		svcListenerName := svc + "-listener"
+
+		rds = append(rds, getRDS(svcRouteConfigName, svc+"-vh", svcListenerName)...)
+		v, err := getLDS(svcRouteConfigName, svcListenerName)
+		if err != nil {
+			c.mu.RUnlock()
+			log.Printf("failed to get snapshot in %s event: %s\n", eventType, err.Error())
+			return
+		}
+		lds = append(lds, v...)
+	}
+	c.mu.RUnlock()
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if err := c.cacheAny.UpdateResource("eds", eds[0]); err != nil {
+		log.Printf("failed to update EDS resource type in %s event: %s\n", eventType, err.Error())
+	}
+	if err := c.cacheAny.UpdateResource("cds", cds[0]); err != nil {
+		log.Printf("failed to update CDS resource type in %s event: %s\n", eventType, err.Error())
+	}
+	if err := c.cacheAny.UpdateResource("rds", rds[0]); err != nil {
+		log.Printf("failed to update RDS resource type in %s event: %s\n", eventType, err.Error())
+	}
+	if err := c.cacheAny.UpdateResource("lds", lds[0]); err != nil {
+		log.Printf("failed to update LDS resource type in %s event: %s\n", eventType, err.Error())
+	}
 }
 
 func (c *k8sInMemoryState) onEventProcess(obj interface{}, eventType string) {

--- a/cmd/xds_k8s/main.go
+++ b/cmd/xds_k8s/main.go
@@ -52,7 +52,7 @@ func main() {
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
-	xdsServer := xds.NewServer(ctx, kcluster.snapshotCache, &callbacks{
+	xdsServer := xds.NewServer(ctx, kcluster.cacheAny, &callbacks{
 		signal:   make(chan struct{}),
 		fetches:  0,
 		requests: 0,

--- a/cmd/xds_k8s/main.go
+++ b/cmd/xds_k8s/main.go
@@ -52,7 +52,7 @@ func main() {
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
-	xdsServer := xds.NewServer(ctx, kcluster.cacheAny, &callbacks{
+	xdsServer := xds.NewServer(ctx, kcluster.muxCache, &callbacks{
 		signal:   make(chan struct{}),
 		fetches:  0,
 		requests: 0,

--- a/deploy/playground/templates/configmap.yaml
+++ b/deploy/playground/templates/configmap.yaml
@@ -12,7 +12,7 @@ data:
         }
       ],
       "node": {
-        "id": "mesh",
+        "id": "any_value_we_dont_evaluate_it",
         "locality": {
           "zone": "dataline_dc",
           "region": "tdb_hardcoded"

--- a/deploy/playground/values_frontend.yaml
+++ b/deploy/playground/values_frontend.yaml
@@ -17,7 +17,7 @@ client: true
 
 args:
   - --host
-  - "xds:///backend-listener"
+  - "xds:///backend"
   - --reqs
   - "-1"
   - --restdur


### PR DESCRIPTION
This PR migrates from the usage of simple cache (aka [snapshots](https://github.com/envoyproxy/go-control-plane#resource-caching))

The main issue with SotW is still persisted but it's now much easier to solve